### PR TITLE
Enforce TLS1.2 on Linux clusters in templates

### DIFF
--- a/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
+++ b/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
@@ -1425,6 +1425,14 @@
                             {
                                 "name": "ClusterProtectionLevel",
                                 "value": "[parameters('clusterProtectionLevel')]"
+                            },
+                            {
+                                "name": "EnforceLinuxMinTlsVersion",
+                                "value": true
+                            },
+                            {
+                                "name": "TLS1_2_CipherList",
+                                "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
                             }
                         ],
                         "name": "Security"

--- a/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json
@@ -609,6 +609,14 @@
               {
                 "name": "ClusterProtectionLevel",
                 "value": "[parameters('clusterProtectionLevel')]"
+              },
+              {
+                "name": "EnforceLinuxMinTlsVersion",
+                "value": true
+              },
+              {
+                "name": "TLS1_2_CipherList",
+                "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
               }
             ],
             "name": "Security"

--- a/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
+++ b/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
@@ -723,6 +723,14 @@
                             {
                                 "name": "ClusterProtectionLevel",
                                 "value": "[parameters('clusterProtectionLevel')]"
+                            },
+                            {
+                                "name": "EnforceLinuxMinTlsVersion",
+                                "value": true
+                            },
+                            {
+                                "name": "TLS1_2_CipherList",
+                                "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
                             }
                         ],
                         "name": "Security"

--- a/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
@@ -608,6 +608,14 @@
               {
                 "name": "ClusterProtectionLevel",
                 "value": "[parameters('clusterProtectionLevel')]"
+              },
+              {
+                "name": "EnforceLinuxMinTlsVersion",
+                "value": true
+              },
+              {
+                "name": "TLS1_2_CipherList",
+                "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
               }
             ],
             "name": "Security"

--- a/5-VM-Ubuntu-1804-1-NodeType-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1804-1-NodeType-Secure/AzureDeploy.json
@@ -608,6 +608,14 @@
               {
                 "name": "ClusterProtectionLevel",
                 "value": "[parameters('clusterProtectionLevel')]"
+              },
+              {
+                "name": "EnforceLinuxMinTlsVersion",
+                "value": true
+              },
+              {
+                "name": "TLS1_2_CipherList",
+                "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
               }
             ],
             "name": "Security"

--- a/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
@@ -1306,6 +1306,14 @@
               {
                 "name": "ClusterProtectionLevel",
                 "value": "[parameters('clusterProtectionLevel')]"
+              },
+              {
+                "name": "EnforceLinuxMinTlsVersion",
+                "value": true
+              },
+              {
+                "name": "TLS1_2_CipherList",
+                "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
               }
             ],
             "name": "Security"

--- a/Ubuntu-NodeType-Loop-Secure/AzureDeploy.json
+++ b/Ubuntu-NodeType-Loop-Secure/AzureDeploy.json
@@ -732,10 +732,20 @@
                     "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.table]"
                 },
                 "fabricSettings": [{
-                    "parameters": [{
-                        "name": "ClusterProtectionLevel",
-                        "value": "[parameters('clusterProtectionLevel')]"
-                    }],
+                    "parameters": [
+                        {
+                            "name": "ClusterProtectionLevel",
+                            "value": "[parameters('clusterProtectionLevel')]"
+                        },
+                        {
+                            "name": "EnforceLinuxMinTlsVersion",
+                            "value": true
+                        },
+                        {
+                            "name": "TLS1_2_CipherList",
+                            "value": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES-128-GCM-SHA256:ECDHE-ECDSA-AES256-CBC-SHA384:ECDHE-ECDSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA256"
+                        }
+                    ],
                     "name": "Security"
                 },
                 {
@@ -767,7 +777,7 @@
                 }
                 ],
                 "managementEndpoint": "[concat('https://',reference(concat(variables('dnsName'),'0')).dnsSettings.fqdn,':',variables('nt0fabricHttpGatewayPort'))]",
-				"copy": [
+                "copy": [
                 {
                         "name":"nodeTypes",
                         "count": "[parameters('loopCount')]",
@@ -803,7 +813,7 @@
                 "clusterName": "[parameters('clusterName')]"
             }
         },
-		{
+        {
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[parameters('slbNSGName')]",
             "location": "[resourceGroup().location]",


### PR DESCRIPTION
By default, these clusters may end up with RC4-based TLS on their
management endpoints. Requiring TLS1.2 and listing cipher suites,
as per the current documentation, can help avoid allowing extremely
outdated cryptographic components here.

## Purpose
This change alters what I understand is the only TLS-related settings for Linux Service Fabric applications into a more secure value from their default in these templates, in the hope that users of these templates do not unwittingly deploy themselves into an insecure state.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```
The changes are to demo SF projects. If someone has sufficient dependencies on the TLS version in the demo being horribly out-of-date, then it may cause impact to them, but this scenario is remarkably unlikely.
## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
Deploy the relevant templates to an azure subscription, using your choice of client

## What to Check
Verify that the following are valid
* Deployment succeeds for these templates and the management endpoints can be accessed on the deployed instances
