### PR TITLE
Update 5-VM-Ubuntu-1-NodeType-Secure-OMS.json

### DIFF
--- a/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
+++ b/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
@@ -38,7 +38,7 @@
         },
         "vmImageSku": {
             "type": "string",
-            "defaultValue": "16.04-LTS"
+            "defaultValue": "20.04-LTS"
         },
         "vmImageVersion": {
             "type": "string",
@@ -695,7 +695,7 @@
             }
         },
         {
-            "apiVersion": "2017-07-01-preview",
+            "apiVersion": "2021-06-01",
             "type": "Microsoft.ServiceFabric/clusters",
             "name": "[parameters('clusterName')]",
             "location": "[parameters('clusterLocation')]",
@@ -761,7 +761,7 @@
                 "provisioningState": "Default",
                 "reliabilityLevel": "Silver",
                 "upgradeMode": "Automatic",
-                "vmImage": "Linux"
+                "vmImage": "Ubuntu20_04"
             },
             "tags": {
                 "resourceType": "Service Fabric",


### PR DESCRIPTION
The value for property vmImage is name of the OS image used. For e.g. - Ubuntu20_04

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Main change is value of property vmImage. In existing template, it is mentioned as Linux while it should be the name of the VM image used. Customers are not aware about that and usually their deployments got failed because of this minute mistake. Others are just updates to outdated versions.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [[repo-address](https://github.com/Azure-Samples/service-fabric-cluster-templates/compare/master...Akshita-Vijay:service-fabric-cluster-templates:vmImage_change)]
cd [service-fabric-cluster-templates]
git checkout [vmImage_change]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->