### PR TITLE
Sf linux node updates

### DIFF
--- a/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
+++ b/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
@@ -813,7 +813,8 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "typeHandlerVersion": "1.1"
+                                    "enableAutomaticUpgrade": true,
+                                    "typeHandlerVersion": "2.0"
                                 }
                             },
                             {
@@ -1295,7 +1296,8 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "typeHandlerVersion": "1.1"
+                                    "enableAutomaticUpgrade": true,
+                                    "typeHandlerVersion": "2.0"
                                 }
                             },
                             {

--- a/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
+++ b/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
@@ -1280,6 +1280,7 @@
                                 "properties": {
                                     "type": "ServiceFabricLinuxNode",
                                     "autoUpgradeMinorVersion": true,
+                                    "enableAutomaticUpgrade": true,
                                     "protectedSettings": {
                                         "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                                         "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -1296,7 +1297,6 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "enableAutomaticUpgrade": true,
                                     "typeHandlerVersion": "2.0"
                                 }
                             },

--- a/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
+++ b/10-VM-Ubuntu-2-NodeType-Secure/AzureDeploy.json
@@ -797,6 +797,7 @@
                                 "properties": {
                                     "type": "ServiceFabricLinuxNode",
                                     "autoUpgradeMinorVersion": true,
+                                    "enableAutomaticUpgrade": true,
                                     "protectedSettings": {
                                         "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                                         "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -813,7 +814,6 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "enableAutomaticUpgrade": true,
                                     "typeHandlerVersion": "2.0"
                                 }
                             },

--- a/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json
@@ -468,6 +468,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -484,7 +485,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json
@@ -484,7 +484,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {

--- a/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
+++ b/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
@@ -506,6 +506,7 @@
                                 "properties": {
                                     "type": "ServiceFabricLinuxNode",
                                     "autoUpgradeMinorVersion": true,
+                                    "enableAutomaticUpgrade": true
                                     "protectedSettings": {
                                         "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                                         "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -520,7 +521,6 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "enableAutomaticUpgrade": true
                                     "typeHandlerVersion": "2.0"
                                 }
                             },

--- a/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
+++ b/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
@@ -520,7 +520,8 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "typeHandlerVersion": "1.1"
+                                    "enableAutomaticUpgrade": true
+                                    "typeHandlerVersion": "2.0"
                                 }
                             },
                             {

--- a/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
@@ -464,6 +464,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -480,7 +481,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
@@ -480,6 +480,7 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
+                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "1.1"
                 }
               },

--- a/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1-NodeTypes-Secure/AzureDeploy.json
@@ -481,7 +481,7 @@
                     }
                   },
                   "enableAutomaticUpgrade": true,
-                  "typeHandlerVersion": "1.1"
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {

--- a/5-VM-Ubuntu-1804-1-NodeType-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1804-1-NodeType-Secure/AzureDeploy.json
@@ -464,6 +464,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -480,7 +481,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/5-VM-Ubuntu-1804-1-NodeType-Secure/AzureDeploy.json
+++ b/5-VM-Ubuntu-1804-1-NodeType-Secure/AzureDeploy.json
@@ -480,7 +480,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {

--- a/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
@@ -550,7 +550,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {
@@ -864,7 +865,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {
@@ -1178,7 +1180,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {

--- a/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
@@ -534,6 +534,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -550,7 +551,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-1804-3-NodeTypes-Secure/AzureDeploy.json
@@ -849,6 +849,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -865,7 +866,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },
@@ -1164,6 +1164,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -1180,7 +1181,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/7-VM-Ubuntu-2004-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-2004-3-NodeTypes-Secure/AzureDeploy.json
@@ -550,7 +550,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {
@@ -864,7 +865,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {
@@ -1178,7 +1180,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {

--- a/7-VM-Ubuntu-2004-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-2004-3-NodeTypes-Secure/AzureDeploy.json
@@ -534,6 +534,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -550,7 +551,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },
@@ -849,6 +849,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -865,7 +866,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },
@@ -1164,6 +1164,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -1180,7 +1181,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/7-VM-Ubuntu-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-3-NodeTypes-Secure/AzureDeploy.json
@@ -550,7 +550,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {
@@ -864,7 +865,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {
@@ -1178,7 +1180,8 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1"
+                  "enableAutomaticUpgrade": true,
+                  "typeHandlerVersion": "2.0"
                 }
               },
               {

--- a/7-VM-Ubuntu-3-NodeTypes-Secure/AzureDeploy.json
+++ b/7-VM-Ubuntu-3-NodeTypes-Secure/AzureDeploy.json
@@ -534,6 +534,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -550,7 +551,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },
@@ -849,6 +849,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -865,7 +866,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },
@@ -1164,6 +1164,7 @@
                 "properties": {
                   "type": "ServiceFabricLinuxNode",
                   "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
                   "protectedSettings": {
                     "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                     "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -1180,7 +1181,6 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "enableAutomaticUpgrade": true,
                   "typeHandlerVersion": "2.0"
                 }
               },

--- a/Ubuntu-NodeType-Loop-Secure/AzureDeploy.json
+++ b/Ubuntu-NodeType-Loop-Secure/AzureDeploy.json
@@ -537,6 +537,7 @@
                                 "properties": {
                                     "type": "ServiceFabricLinuxNode",
                                     "autoUpgradeMinorVersion": true,
+                                    "enableAutomaticUpgrade": true,
                                     "protectedSettings": {
                                         "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
                                         "StorageAccountKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key2]"
@@ -552,7 +553,6 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "enableAutomaticUpgrade": true,
                                     "typeHandlerVersion": "2.0"
                                 }
                             },

--- a/Ubuntu-NodeType-Loop-Secure/AzureDeploy.json
+++ b/Ubuntu-NodeType-Loop-Secure/AzureDeploy.json
@@ -552,7 +552,8 @@
                                             "x509StoreName": "[parameters('certificateStoreValue')]"
                                         }
                                     },
-                                    "typeHandlerVersion": "1.1"
+                                    "enableAutomaticUpgrade": true,
+                                    "typeHandlerVersion": "2.0"
                                 }
                             },
                             {


### PR DESCRIPTION
What’s changing?
Today to upgrade the Service Fabric Linux Extension, customers must make a change to the extension settings and redeploy or restart VMs to pick up the new extension version. With this change, once a new minor version of the extension is available, all VMs in a node type will be automatically updated with the new extension version.
 
Why?
Customer can pick up the latest bug fixes without having to do manual steps, and by allowing minor version of automatic extension updates, we support SDP and Project Standard requirements.
 
How?
To enable Automatic Upgrades, add the following enableAutomaticUpgrade property to extension settings and update the typeHandlerVersion to 2.0:
 
"properties": {
   "enableAutomaticUpgrade": true,
   "typeHandlerVersion": "2.0",
   ...
}
 
For more information, see [Automatic Extension Upgrade for VMs and Scale Sets in Azure - Azure Virtual Machines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-extension-upgrade)




Findings:
	Present in:
		10-VM-Ubunut-2-NodeType-Secure
			Two times (approx. lines: 798, 1280)
		5-VM-RHEL-1-NodeTypes-Secure  
			One time (approx. line: 469)
		5-VM-Ubuntu-1-NodeType-Secure-OMS
			One time (approx. line: 507)
		5-VM-Ubuntu-1-NodeTypes-Secure
			One time (approx. line: 465)
		5-VM-Ubuntu-1804-1-NodeType-Secure
			One time (approx. line: 465)
		7-VM-Ubuntu-1804-3-NodeTypes-Secure
			Three times (approx. lines: 535, 849, 1163)
		7-VM-Ubuntu-2004-3-NodeTypes-Secure
			Three times (approx. lines: 535, 849, 1163)
		7-VM-Ubuntu-3-NodeTypes-Secure
			Three times (approx. lines: 535, 849, 1163)
		Ubuntu-NodeType-Loop-Secure
			One time (approx. line: 538)