### PR TITLE
Managed os disks

### DIFF
--- a/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
+++ b/5-VM-Ubuntu-1-NodeType-Secure-OMS/5-VM-Ubuntu-1-NodeType-Secure-OMS.json
@@ -614,16 +614,11 @@
                             "version": "[parameters('vmImageVersion')]"
                         },
                         "osDisk": {
-                            "vhdContainers": [
-                                "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray0')[0]), variables('storageApiVersion')).primaryEndpoints.blob, variables('vmStorageAccountContainerName'))]",
-                                "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray0')[1]), variables('storageApiVersion')).primaryEndpoints.blob, variables('vmStorageAccountContainerName'))]",
-                                "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray0')[2]), variables('storageApiVersion')).primaryEndpoints.blob, variables('vmStorageAccountContainerName'))]",
-                                "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray0')[3]), variables('storageApiVersion')).primaryEndpoints.blob, variables('vmStorageAccountContainerName'))]",
-                                "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray0')[4]), variables('storageApiVersion')).primaryEndpoints.blob, variables('vmStorageAccountContainerName'))]"
-                            ],
-                            "name": "vmssosdisk",
                             "caching": "ReadOnly",
-                            "createOption": "FromImage"
+                            "createOption": "FromImage",
+                            "managedDisk": {
+                                "storageAccountType": "[parameters('storageAccountType')]"
+                            }
                         }
                     }
                 }

--- a/5-VM-Windows-OMS-UnSecure/sfclusteroms.json
+++ b/5-VM-Windows-OMS-UnSecure/sfclusteroms.json
@@ -558,16 +558,11 @@
                             "version": "[variables('vmImageVersion')]"
                         },
                         "osDisk": {
-                            "vhdContainers": [
-                                "[concat('https://', variables('uniqueStringArray0')[0], '.blob.core.windows.net/', variables('vmStorageAccountContainerName'))]",
-                                "[concat('https://', variables('uniqueStringArray0')[1], '.blob.core.windows.net/', variables('vmStorageAccountContainerName'))]",
-                                "[concat('https://', variables('uniqueStringArray0')[2], '.blob.core.windows.net/', variables('vmStorageAccountContainerName'))]",
-                                "[concat('https://', variables('uniqueStringArray0')[3], '.blob.core.windows.net/', variables('vmStorageAccountContainerName'))]",
-                                "[concat('https://', variables('uniqueStringArray0')[4], '.blob.core.windows.net/', variables('vmStorageAccountContainerName'))]"
-                            ],
-                            "name": "vmssosdisk",
-                            "caching": "ReadWrite",
-                            "createOption": "FromImage"
+                            "caching": "ReadOnly",
+                            "createOption": "FromImage",
+                            "managedDisk": {
+                                "storageAccountType": "[parameters('storageAccountType')]"
+                            }
                         }
                     }
                 }

--- a/Cert-Rollover-Sample/5-VM-1-NodeTypes-Secure_Step1.json
+++ b/Cert-Rollover-Sample/5-VM-1-NodeTypes-Secure_Step1.json
@@ -497,12 +497,11 @@
               "version": "[variables('vmImageVersion')]"
             },
             "osDisk": {
-              "vhdContainers": [
-                "[concat('http://',variables('vmStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'))]"
-              ],
-              "name": "vmssosdisk",
               "caching": "ReadOnly",
-              "createOption": "FromImage"
+              "createOption": "FromImage",
+              "managedDisk": {
+                  "storageAccountType": "[parameters('storageAccountType')]"
+              }
             }
           }
         }

--- a/Cert-Rollover-Sample/5-VM-1-NodeTypes-Secure_Step2.json
+++ b/Cert-Rollover-Sample/5-VM-1-NodeTypes-Secure_Step2.json
@@ -517,12 +517,11 @@
               "version": "[variables('vmImageVersion')]"
             },
             "osDisk": {
-              "vhdContainers": [
-                "[concat('http://',variables('vmStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'))]"
-              ],
-              "name": "vmssosdisk",
               "caching": "ReadOnly",
-              "createOption": "FromImage"
+              "createOption": "FromImage",
+              "managedDisk": {
+                  "storageAccountType": "[parameters('storageAccountType')]"
+              }
             }
           }
         }


### PR DESCRIPTION
Meng Lin:
"...we may have customers that still use non-managed OS disk, i.e. uses a customer provided storage account for hosting the vhds for their VMSS.

Not sure if anyone knows what would be the impact if customers disable shared keys on those storage account. I would assume they continue to work, but we may want to clarify that or advise customers to move to use managed OS disk if they raise any questions on this.

We should also clean up templates in our repo (used by our own tests / deployments) to use managed OS disk."

These changes are done in accordance with the last line at Abhay Shah's request.